### PR TITLE
Ignore local npm and gh cache files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ coverage/
 # Package
 *.tgz
 .npm-cache/
+.npmrc
+.gh-cache/
 
 # Local agent guidance
 AGENTS.md


### PR DESCRIPTION
## Summary
- ignore local .npmrc files
- ignore .gh-cache directories created by local tooling

## Testing
- not run (gitignore-only change)