### PR TITLE
chore: align npm publishing with trusted publishers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          # Trusted publishing requires a recent enough Node runtime for npm OIDC.
+          node-version: 24
           cache: npm
           registry-url: https://registry.npmjs.org/
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ x402 is a payment protocol built on HTTP status code `402 Payment Required`. It 
 | [x402-server](./packages/x402-server) | Server SDK - protect routes, verify payments | `npm i @fastxyz/x402-server` |
 | [x402-facilitator](./packages/x402-facilitator) | Facilitator - verify signatures, settle on-chain | `npm i @fastxyz/x402-facilitator` |
 
+## Releasing
+
+Package publishing is handled by GitHub Actions via npm trusted publishing. See [RELEASING.md](./RELEASING.md) for the one-time npm setup and the coordinated tag-based release flow.
+
 ## Quick Start
 
 ### 1. Run a Facilitator

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,10 +11,20 @@ This monorepo publishes three packages to npm:
 ## One-time npm setup
 
 1. Create or verify access to the `@fastxyz` npm scope.
-2. Configure npm trusted publishing for `fastxyz/x402-sdk`.
-3. Register the publish workflow filename exactly as `.github/workflows/publish.yml`.
+2. Ensure the GitHub repo is public at `fastxyz/x402-sdk`.
+3. In npm, configure a trusted publisher for each package:
+   - `@fastxyz/x402-client`
+   - `@fastxyz/x402-server`
+   - `@fastxyz/x402-facilitator`
+4. For each trusted publisher entry, use:
+   - Owner: `fastxyz`
+   - Repository: `x402-sdk`
+   - Workflow filename: `publish.yml`
+5. Do not configure an `NPM_TOKEN` secret for the normal release path. This workflow is expected to authenticate via GitHub OIDC trusted publishing.
 
 Trusted publishing is the expected path for this repo. Do not add a long-lived npm token unless trusted publishing is unavailable.
+
+The publish workflow runs on GitHub-hosted runners and pins a current Node release so npm trusted publishing and provenance work reliably.
 
 ## Release strategy
 


### PR DESCRIPTION
## Summary
- pin the publish workflow to Node 24 for npm trusted publishing compatibility
- document the package-level npm trusted publisher setup for this repo
- add a short README note pointing release setup to RELEASING.md

## Testing
- not run (workflow/docs only)