### PR TITLE
fix: allow express 5 peers for x402 server packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1012,22 +1012,21 @@
       "license": "MIT"
     },
     "node_modules/@types/express": {
-      "version": "4.17.25",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
-      "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.33",
-        "@types/qs": "*",
-        "@types/serve-static": "^1"
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.19.8",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
-      "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
+      "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1041,13 +1040,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/mime": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
-      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
       "dev": true,
       "license": "MIT"
     },
@@ -1086,25 +1078,13 @@
       }
     },
     "node_modules/@types/serve-static": {
-      "version": "1.15.10",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
-      "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-errors": "*",
-        "@types/node": "*",
-        "@types/send": "<1"
-      }
-    },
-    "node_modules/@types/serve-static/node_modules/@types/send": {
-      "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
-      "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/mime": "^1",
         "@types/node": "*"
       }
     },
@@ -2311,7 +2291,7 @@
         "viem": "^2.21.0"
       },
       "devDependencies": {
-        "@types/express": "^4.17.21",
+        "@types/express": "^5.0.3",
         "typescript": "^5.3.3",
         "vitest": "^1.6.0"
       },
@@ -2319,7 +2299,7 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "express": "^4.18.0"
+        "express": "^4.18.0 || ^5.0.0"
       },
       "peerDependenciesMeta": {
         "express": {
@@ -2370,7 +2350,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "express": "^4.18.0"
+        "express": "^4.18.0 || ^5.0.0"
       },
       "peerDependenciesMeta": {
         "express": {

--- a/packages/x402-facilitator/package.json
+++ b/packages/x402-facilitator/package.json
@@ -38,12 +38,12 @@
     "viem": "^2.21.0"
   },
   "devDependencies": {
-    "@types/express": "^4.17.21",
+    "@types/express": "^5.0.3",
     "typescript": "^5.3.3",
     "vitest": "^1.6.0"
   },
   "peerDependencies": {
-    "express": "^4.18.0"
+    "express": "^4.18.0 || ^5.0.0"
   },
   "peerDependenciesMeta": {
     "express": {

--- a/packages/x402-server/package.json
+++ b/packages/x402-server/package.json
@@ -39,7 +39,7 @@
     "typescript": "^5.3.3"
   },
   "peerDependencies": {
-    "express": "^4.18.0"
+    "express": "^4.18.0 || ^5.0.0"
   },
   "peerDependenciesMeta": {
     "express": {


### PR DESCRIPTION
Summary
- widen the express peer range in @fastxyz/x402-facilitator and @fastxyz/x402-server to allow Express 5
- update the facilitator package to build against @types/express 5

Why
A downstream app hit npm ci failures when upgrading to express 5 because the published packages still declare express ^4.18.0 only. The current middleware surface is compatible with Express 5, so the peer range is unnecessarily strict.

Verification
- npm test
- npm run build