### PR TITLE
fix: accept CAIP-2 EVM network ids in x402-client

### DIFF
--- a/packages/x402-client/src/__tests__/bridge.test.ts
+++ b/packages/x402-client/src/__tests__/bridge.test.ts
@@ -9,6 +9,7 @@ import { describe, it, afterEach } from 'node:test';
 import assert from 'node:assert';
 import { 
   getBridgeConfig,
+  resolveBridgeNetworkContext,
 } from '../bridge.js';
 
 const originalFetch = globalThis.fetch;
@@ -69,6 +70,28 @@ describe('AllSet Bridge', () => {
       assert.ok(typeof config.usdcAddress === 'string');
       assert.ok(typeof config.fastBridgeAddress === 'string');
       assert.ok(typeof config.relayerUrl === 'string');
+    });
+  });
+
+  describe('resolveBridgeNetworkContext', () => {
+    it('should keep sepolia networks on testnet Fast and testUSDC', () => {
+      const context = resolveBridgeNetworkContext('arbitrum-sepolia');
+      assert.deepStrictEqual(context, {
+        normalizedNetwork: 'arbitrum-sepolia',
+        allsetProviderNetwork: 'testnet',
+        fastNetwork: 'testnet',
+        tokenName: 'testUSDC',
+      });
+    });
+
+    it('should keep Base mainnet on mainnet Fast USDC while using the AllSet testnet provider namespace', () => {
+      const context = resolveBridgeNetworkContext('eip155:8453');
+      assert.deepStrictEqual(context, {
+        normalizedNetwork: 'base',
+        allsetProviderNetwork: 'testnet',
+        fastNetwork: 'mainnet',
+        tokenName: 'USDC',
+      });
     });
   });
 

--- a/packages/x402-client/src/__tests__/bridge.test.ts
+++ b/packages/x402-client/src/__tests__/bridge.test.ts
@@ -84,11 +84,11 @@ describe('AllSet Bridge', () => {
       });
     });
 
-    it('should keep Base mainnet on mainnet Fast USDC while using the AllSet testnet provider namespace', () => {
+    it('should keep Base mainnet on mainnet Fast USDC and the AllSet mainnet provider namespace', () => {
       const context = resolveBridgeNetworkContext('eip155:8453');
       assert.deepStrictEqual(context, {
         normalizedNetwork: 'base',
-        allsetProviderNetwork: 'testnet',
+        allsetProviderNetwork: 'mainnet',
         fastNetwork: 'mainnet',
         tokenName: 'USDC',
       });

--- a/packages/x402-client/src/__tests__/bridge.test.ts
+++ b/packages/x402-client/src/__tests__/bridge.test.ts
@@ -44,6 +44,14 @@ describe('AllSet Bridge', () => {
       assert.ok(config.fastBridgeAddress.startsWith('fast'));
     });
 
+    it('should return config for CAIP-2 base mainnet ids', () => {
+      const config = getBridgeConfig('eip155:8453');
+      assert.ok(config);
+      assert.strictEqual(config.chainId, 8453);
+      assert.ok(config.usdcAddress.startsWith('0x'));
+      assert.ok(config.fastBridgeAddress.startsWith('fast'));
+    });
+
     it('should return null for unsupported network', () => {
       const config = getBridgeConfig('ethereum-mainnet');
       assert.strictEqual(config, null);

--- a/packages/x402-client/src/__tests__/evm.test.ts
+++ b/packages/x402-client/src/__tests__/evm.test.ts
@@ -24,6 +24,10 @@ describe('EVM Payment Handler', () => {
       assert.ok(EVM_NETWORKS.includes('arbitrum'));
       assert.ok(EVM_NETWORKS.includes('base'));
     });
+
+    it('should keep CAIP-2 aliases out of the exported canonical list', () => {
+      assert.ok(!(EVM_NETWORKS as readonly string[]).includes('eip155:8453'));
+    });
   });
 
   describe('handleEvmPayment', () => {
@@ -181,6 +185,48 @@ describe('EVM Payment Handler', () => {
       assert.strictEqual(result.payment.amount, '0.5');
       assert.strictEqual(result.payment.recipient, '0x1131623344cFdb04D06a9eD511BEc56FF6Ae4372');
       assert.ok(result.payment.txHash);
+    });
+
+    it('should accept CAIP-2 network ids when building the EIP-3009 domain', async () => {
+      const paymentRequired = mock402Response('eip155:8453', '100000');
+      let paymentPayload: Record<string, unknown> | null = null;
+
+      globalThis.fetch = async (input: string | URL | Request, init?: RequestInit) => {
+        const body = init?.body ? JSON.parse(init.body as string) : null;
+
+        if (body?.method === 'eth_call') {
+          return new Response(JSON.stringify({
+            jsonrpc: '2.0',
+            id: body.id,
+            result: '0x00000000000000000000000000000000000000000000000000000000000186a0',
+          }), { status: 200 });
+        }
+
+        if (init?.headers && (init.headers as Record<string, string>)['X-PAYMENT']) {
+          const header = (init.headers as Record<string, string>)['X-PAYMENT'];
+          paymentPayload = JSON.parse(Buffer.from(header, 'base64').toString()) as Record<string, unknown>;
+          return new Response(JSON.stringify({ success: true, txHash: '0xbase123' }), { status: 200 });
+        }
+
+        return new Response('{}', { status: 200 });
+      };
+
+      const result = await handleEvmPayment(
+        'https://api.example.com/data',
+        'GET',
+        {},
+        undefined,
+        paymentRequired,
+        paymentRequired.accepts![0],
+        mockEvmWallet,
+        false,
+        []
+      );
+
+      assert.strictEqual(result.success, true);
+      assert.strictEqual(result.payment?.network, 'eip155:8453');
+      assert.ok(paymentPayload);
+      assert.strictEqual(paymentPayload['network'], 'eip155:8453');
     });
 
     it('should handle verbose logging', async () => {

--- a/packages/x402-client/src/__tests__/helpers.ts
+++ b/packages/x402-client/src/__tests__/helpers.ts
@@ -24,7 +24,17 @@ export const mockFastWallet: FastWallet = {
 // ─── Mock 402 Responses ───────────────────────────────────────────────────────
 
 export function mock402Response(network: string, amount: string = '100000'): PaymentRequired {
-  const isEvm = ['arbitrum-sepolia', 'base-sepolia', 'arbitrum', 'base'].includes(network);
+  const isEvm = [
+    'arbitrum-sepolia',
+    'base-sepolia',
+    'arbitrum',
+    'base',
+    'eip155:11155111',
+    'eip155:42161',
+    'eip155:421614',
+    'eip155:8453',
+    'eip155:84532',
+  ].includes(network);
   
   return {
     x402Version: 1,

--- a/packages/x402-client/src/__tests__/index.test.ts
+++ b/packages/x402-client/src/__tests__/index.test.ts
@@ -34,6 +34,7 @@ describe('x402-client', () => {
       assert.ok(Array.isArray(EVM_NETWORKS));
       assert.ok(EVM_NETWORKS.includes('arbitrum-sepolia'));
       assert.ok(EVM_NETWORKS.includes('base-sepolia'));
+      assert.ok(!(EVM_NETWORKS as readonly string[]).includes('eip155:8453'));
     });
   });
 
@@ -132,6 +133,38 @@ describe('x402-client', () => {
         }),
         /No matching wallet/
       );
+    });
+
+    it('should accept CAIP-2 EVM network ids during wallet matching', async () => {
+      let paymentHeaderSent = false;
+
+      globalThis.fetch = async (input: string | URL | Request, init?: RequestInit) => {
+        const body = init?.body ? JSON.parse(init.body as string) : null;
+
+        if (body?.method === 'eth_call') {
+          return new Response(JSON.stringify({
+            jsonrpc: '2.0',
+            id: body.id,
+            result: '0x00000000000000000000000000000000000000000000000000000000000186a0',
+          }), { status: 200 });
+        }
+
+        if (init?.headers && (init.headers as Record<string, string>)['X-PAYMENT']) {
+          paymentHeaderSent = true;
+          return new Response(JSON.stringify({ success: true, data: 'paid content' }), { status: 200 });
+        }
+
+        return new Response(JSON.stringify(mock402Response('eip155:8453')), { status: 402 });
+      };
+
+      const result = await x402Pay({
+        url: 'https://api.example.com/paid',
+        wallet: mockEvmWallet,
+      });
+
+      assert.strictEqual(result.success, true);
+      assert.ok(paymentHeaderSent, 'X-PAYMENT header should be sent for CAIP-2 EVM quotes');
+      assert.strictEqual(result.payment?.network, 'eip155:8453');
     });
 
     it('should accept array of wallets', async () => {

--- a/packages/x402-client/src/bridge.ts
+++ b/packages/x402-client/src/bridge.ts
@@ -78,6 +78,26 @@ export interface BridgeResult {
   error?: string;
 }
 
+interface BridgeNetworkContext {
+  normalizedNetwork: string;
+  allsetProviderNetwork: 'testnet' | 'mainnet';
+  fastNetwork: 'testnet' | 'mainnet';
+  tokenName: 'USDC' | 'testUSDC';
+}
+
+export function resolveBridgeNetworkContext(network: string): BridgeNetworkContext {
+  const normalizedNetwork = normalizeEvmNetwork(network) ?? network;
+  const isSepolia = normalizedNetwork.includes('sepolia');
+
+  return {
+    normalizedNetwork,
+    // allset-sdk currently exposes Base mainnet under the "testnet" provider namespace.
+    allsetProviderNetwork: isSepolia || normalizedNetwork === 'base' ? 'testnet' : 'mainnet',
+    fastNetwork: isSepolia ? 'testnet' : 'mainnet',
+    tokenName: isSepolia ? 'testUSDC' : 'USDC',
+  };
+}
+
 // ─── Public Functions ─────────────────────────────────────────────────────────
 
 /**
@@ -85,10 +105,8 @@ export interface BridgeResult {
  * Configurations are loaded from @fastxyz/allset-sdk.
  */
 export function getBridgeConfig(network: string): BridgeChainConfig | null {
-  const normalizedNetwork = normalizeEvmNetwork(network) ?? network;
-  // Determine which AllSet network to use based on chain name
-  const isTestnet = normalizedNetwork.includes('sepolia') || normalizedNetwork === 'base';
-  const allset = getAllSetProvider(isTestnet ? 'testnet' : 'mainnet');
+  const { normalizedNetwork, allsetProviderNetwork } = resolveBridgeNetworkContext(network);
+  const allset = getAllSetProvider(allsetProviderNetwork);
   
   // Map x402 network names to allset-sdk chain names
   const chainName = normalizedNetwork === 'ethereum-sepolia' ? 'ethereum-sepolia'
@@ -142,7 +160,7 @@ export async function getFastBalance(wallet: X402FastWallet): Promise<bigint> {
  */
 export async function bridgeFastusdcToUsdc(params: BridgeParams): Promise<BridgeResult> {
   const { fastWallet, evmReceiverAddress, amount, network, verbose = false, logs = [] } = params;
-  const normalizedNetwork = normalizeEvmNetwork(network) ?? network;
+  const { normalizedNetwork, allsetProviderNetwork, fastNetwork, tokenName } = resolveBridgeNetworkContext(network);
   
   const log = (msg: string) => {
     if (verbose) {
@@ -151,11 +169,6 @@ export async function bridgeFastusdcToUsdc(params: BridgeParams): Promise<Bridge
     }
   };
 
-  // Determine network type
-  const isTestnet = normalizedNetwork.includes('sepolia') || normalizedNetwork === 'base';
-  const allsetNetwork = isTestnet ? 'testnet' : 'mainnet';
-  const tokenName = isTestnet ? 'testUSDC' : 'USDC';
-  
   log(`━━━ AllSet Bridge START ━━━`);
   log(`  Amount: ${Number(amount) / 1e6} ${tokenName}`);
   log(`  From: ${fastWallet.address}`);
@@ -164,10 +177,10 @@ export async function bridgeFastusdcToUsdc(params: BridgeParams): Promise<Bridge
 
   try {
     // Get AllSet provider
-    const allset = getAllSetProvider(allsetNetwork);
+    const allset = getAllSetProvider(allsetProviderNetwork);
     
     // Get Fast provider for the wallet
-    const fastProvider = getFastProvider(allsetNetwork);
+    const fastProvider = getFastProvider(fastNetwork);
     
     // Create a FastWallet from raw keys using @fastxyz/sdk
     log(`[Step 1] Creating FastWallet from keys...`);

--- a/packages/x402-client/src/bridge.ts
+++ b/packages/x402-client/src/bridge.ts
@@ -106,17 +106,11 @@ export function resolveBridgeNetworkContext(network: string): BridgeNetworkConte
 export function getBridgeConfig(network: string): BridgeChainConfig | null {
   const { normalizedNetwork, allsetProviderNetwork } = resolveBridgeNetworkContext(network);
   const allset = getAllSetProvider(allsetProviderNetwork);
-  
-  // Map x402 network names to allset-sdk chain names
-  const chainName = normalizedNetwork === 'ethereum-sepolia' ? 'ethereum-sepolia'
-    : normalizedNetwork === 'arbitrum-sepolia' ? 'arbitrum-sepolia'
-    : normalizedNetwork === 'base' ? 'base'
-    : normalizedNetwork;
-  
-  const chainConfig = allset.getChainConfig(chainName);
+
+  const chainConfig = allset.getChainConfig(normalizedNetwork);
   if (!chainConfig) return null;
-  
-  const tokenConfig = allset.getTokenConfig(chainName, 'USDC');
+
+  const tokenConfig = allset.getTokenConfig(normalizedNetwork, 'USDC');
   if (!tokenConfig) return null;
   
   return {

--- a/packages/x402-client/src/bridge.ts
+++ b/packages/x402-client/src/bridge.ts
@@ -8,6 +8,7 @@
 import { AllSetProvider } from '@fastxyz/allset-sdk/node';
 import { FastProvider, FastWallet } from '@fastxyz/sdk';
 import type { FastWallet as X402FastWallet } from './types.js';
+import { normalizeEvmNetwork } from './networks.js';
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -84,15 +85,16 @@ export interface BridgeResult {
  * Configurations are loaded from @fastxyz/allset-sdk.
  */
 export function getBridgeConfig(network: string): BridgeChainConfig | null {
+  const normalizedNetwork = normalizeEvmNetwork(network) ?? network;
   // Determine which AllSet network to use based on chain name
-  const isTestnet = network.includes('sepolia') || network === 'base';
+  const isTestnet = normalizedNetwork.includes('sepolia') || normalizedNetwork === 'base';
   const allset = getAllSetProvider(isTestnet ? 'testnet' : 'mainnet');
   
   // Map x402 network names to allset-sdk chain names
-  const chainName = network === 'ethereum-sepolia' ? 'ethereum-sepolia'
-    : network === 'arbitrum-sepolia' ? 'arbitrum-sepolia'
-    : network === 'base' ? 'base'
-    : network;
+  const chainName = normalizedNetwork === 'ethereum-sepolia' ? 'ethereum-sepolia'
+    : normalizedNetwork === 'arbitrum-sepolia' ? 'arbitrum-sepolia'
+    : normalizedNetwork === 'base' ? 'base'
+    : normalizedNetwork;
   
   const chainConfig = allset.getChainConfig(chainName);
   if (!chainConfig) return null;
@@ -140,6 +142,7 @@ export async function getFastBalance(wallet: X402FastWallet): Promise<bigint> {
  */
 export async function bridgeFastusdcToUsdc(params: BridgeParams): Promise<BridgeResult> {
   const { fastWallet, evmReceiverAddress, amount, network, verbose = false, logs = [] } = params;
+  const normalizedNetwork = normalizeEvmNetwork(network) ?? network;
   
   const log = (msg: string) => {
     if (verbose) {
@@ -149,14 +152,14 @@ export async function bridgeFastusdcToUsdc(params: BridgeParams): Promise<Bridge
   };
 
   // Determine network type
-  const isTestnet = network.includes('sepolia') || network === 'base';
+  const isTestnet = normalizedNetwork.includes('sepolia') || normalizedNetwork === 'base';
   const allsetNetwork = isTestnet ? 'testnet' : 'mainnet';
   const tokenName = isTestnet ? 'testUSDC' : 'fastUSDC';
   
   log(`━━━ AllSet Bridge START ━━━`);
   log(`  Amount: ${Number(amount) / 1e6} ${tokenName}`);
   log(`  From: ${fastWallet.address}`);
-  log(`  To: ${evmReceiverAddress} on ${network}`);
+  log(`  To: ${evmReceiverAddress} on ${normalizedNetwork}`);
   log(`  Using: @fastxyz/allset-sdk sendToExternal()`);
 
   try {
@@ -184,7 +187,7 @@ export async function bridgeFastusdcToUsdc(params: BridgeParams): Promise<Bridge
     // Call allset-sdk's sendToExternal
     log(`[Step 2] Calling allset.sendToExternal()...`);
     const result = await allset.sendToExternal({
-      chain: network,
+      chain: normalizedNetwork,
       token: tokenName,
       amount: amount.toString(),
       from: fastWallet.address,

--- a/packages/x402-client/src/bridge.ts
+++ b/packages/x402-client/src/bridge.ts
@@ -91,8 +91,7 @@ export function resolveBridgeNetworkContext(network: string): BridgeNetworkConte
 
   return {
     normalizedNetwork,
-    // allset-sdk currently exposes Base mainnet under the "testnet" provider namespace.
-    allsetProviderNetwork: isSepolia || normalizedNetwork === 'base' ? 'testnet' : 'mainnet',
+    allsetProviderNetwork: isSepolia ? 'testnet' : 'mainnet',
     fastNetwork: isSepolia ? 'testnet' : 'mainnet',
     tokenName: isSepolia ? 'testUSDC' : 'USDC',
   };

--- a/packages/x402-client/src/evm.ts
+++ b/packages/x402-client/src/evm.ts
@@ -16,6 +16,7 @@ import type {
   Eip3009Authorization 
 } from './types.js';
 import { bridgeFastusdcToUsdc, getFastBalance, getBridgeConfig } from './bridge.js';
+import { CANONICAL_EVM_NETWORKS, normalizeEvmNetwork } from './networks.js';
 
 /**
  * Network configuration
@@ -35,7 +36,7 @@ const NETWORK_MAP: Record<string, NetworkConfig> = {
   'base': { chain: base, network: 'mainnet', chainId: 8453 },
 };
 
-export const EVM_NETWORKS = Object.keys(NETWORK_MAP);
+export const EVM_NETWORKS = [...CANONICAL_EVM_NETWORKS];
 
 /**
  * Get EVM USDC balance
@@ -128,7 +129,8 @@ export async function handleEvmPayment(
   log(`  Fast wallet available: ${fastWallet ? 'yes' : 'no'}`);
 
   // Get network config
-  const networkConfig = NETWORK_MAP[evmReq.network];
+  const normalizedNetwork = normalizeEvmNetwork(evmReq.network);
+  const networkConfig = normalizedNetwork ? NETWORK_MAP[normalizedNetwork] : undefined;
   if (!networkConfig) {
     throw new Error(`Unsupported EVM network: ${evmReq.network}. Supported: ${EVM_NETWORKS.join(', ')}`);
   }

--- a/packages/x402-client/src/index.ts
+++ b/packages/x402-client/src/index.ts
@@ -52,6 +52,7 @@ import type {
 
 import { handleFastPayment, FAST_NETWORKS } from './fast.js';
 import { handleEvmPayment, EVM_NETWORKS } from './evm.js';
+import { normalizeEvmNetwork } from './networks.js';
 
 export { FAST_NETWORKS, EVM_NETWORKS };
 
@@ -195,7 +196,7 @@ export async function x402Pay(params: X402PayParams): Promise<X402PayResult> {
   log(`  Available networks: ${availableNetworks.join(', ')}`);
 
   const fastReq = paymentRequired.accepts.find(r => FAST_NETWORKS.includes(r.network));
-  const evmReq = paymentRequired.accepts.find(r => EVM_NETWORKS.includes(r.network));
+  const evmReq = paymentRequired.accepts.find(r => normalizeEvmNetwork(r.network) !== null);
 
   log(`  Fast match: ${fastReq?.network ?? 'none'}`);
   log(`  EVM match: ${evmReq?.network ?? 'none'}`);

--- a/packages/x402-client/src/networks.ts
+++ b/packages/x402-client/src/networks.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared network identifiers used by x402-client.
+ */
+
+const EVM_NETWORK_ALIASES: Record<string, string> = {
+  "eip155:11155111": "ethereum-sepolia",
+  "eip155:42161": "arbitrum",
+  "eip155:421614": "arbitrum-sepolia",
+  "eip155:8453": "base",
+  "eip155:84532": "base-sepolia",
+};
+
+export const CANONICAL_EVM_NETWORKS = [
+  "ethereum-sepolia",
+  "arbitrum-sepolia",
+  "arbitrum",
+  "base-sepolia",
+  "base",
+] as const;
+
+export type CanonicalEvmNetwork = (typeof CANONICAL_EVM_NETWORKS)[number];
+
+export function normalizeEvmNetwork(network: string): CanonicalEvmNetwork | null {
+  const normalized = EVM_NETWORK_ALIASES[network] ?? network;
+  return CANONICAL_EVM_NETWORKS.includes(normalized as CanonicalEvmNetwork)
+    ? (normalized as CanonicalEvmNetwork)
+    : null;
+}

--- a/packages/x402-facilitator/src/chains.ts
+++ b/packages/x402-facilitator/src/chains.ts
@@ -17,6 +17,17 @@ import {
 import type { Chain } from "viem";
 import type { EvmChainConfig } from "./types.js";
 
+const EVM_NETWORK_ALIASES: Record<string, string> = {
+  "eip155:1": "ethereum",
+  "eip155:11155111": "ethereum-sepolia",
+  "eip155:42161": "arbitrum",
+  "eip155:421614": "arbitrum-sepolia",
+  "eip155:8453": "base",
+  "eip155:84532": "base-sepolia",
+  "eip155:10": "optimism",
+  "eip155:137": "polygon",
+};
+
 /**
  * EIP-3009 metadata for USDC contracts (x402-specific, not in SDKs)
  */
@@ -163,11 +174,15 @@ export const FAST_TRUSTED_COMMITTEE_PUBLIC_KEYS: Record<string, string[]> = {
   ],
 };
 
+export function normalizeEvmNetwork(network: string): string {
+  return EVM_NETWORK_ALIASES[network] ?? network;
+}
+
 /**
  * Get chain config for a network
  */
 export function getEvmChainConfig(network: string): EvmChainConfig | null {
-  return EVM_CHAINS[network] || null;
+  return EVM_CHAINS[normalizeEvmNetwork(network)] || null;
 }
 
 /**

--- a/packages/x402-facilitator/src/types.ts
+++ b/packages/x402-facilitator/src/types.ts
@@ -3,6 +3,7 @@
  * Aligned with reference implementation
  */
 
+import { normalizeEvmNetwork } from "./chains.js";
 import type { Chain } from "viem";
 
 /**
@@ -147,6 +148,7 @@ export function getNetworkType(network: string): NetworkType {
  * Get chain ID from network name
  */
 export function getNetworkId(network: string): number {
+  const normalizedNetwork = normalizeEvmNetwork(network);
   const networkIds: Record<string, number> = {
     "ethereum": 1,
     "ethereum-sepolia": 11155111,
@@ -157,5 +159,5 @@ export function getNetworkId(network: string): number {
     "optimism": 10,
     "polygon": 137,
   };
-  return networkIds[network] || 0;
+  return networkIds[normalizedNetwork] || 0;
 }

--- a/packages/x402-facilitator/src/verify.test.ts
+++ b/packages/x402-facilitator/src/verify.test.ts
@@ -6,6 +6,7 @@ import { generateKeyPairSync, sign, type KeyObject } from "node:crypto";
 import type { FastTransactionCertificate } from "@fastxyz/sdk/core";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { verify } from "./verify.js";
+import { getEvmChainConfig, normalizeEvmNetwork } from "./chains.js";
 import {
   bytesToHex,
   createFastTransactionSigningMessage,
@@ -884,6 +885,11 @@ describe("verify", () => {
   });
 
   describe("EVM payments", () => {
+    it("normalizes CAIP-2 aliases to the canonical EVM chain config", () => {
+      expect(normalizeEvmNetwork("eip155:8453")).toBe("base");
+      expect(getEvmChainConfig("eip155:8453")).toBe(getEvmChainConfig("base"));
+    });
+
     it("rejects invalid payload structure", async () => {
       const payload: PaymentPayload = {
         x402Version: 1,
@@ -907,6 +913,41 @@ describe("verify", () => {
       const result = await verify(payload, requirement);
       expect(result.isValid).toBe(false);
       expect(result.invalidReason).toBe("invalid_payload");
+    });
+
+    it("does not reject CAIP-2 aliases as invalid networks before signature verification", async () => {
+      const payload: PaymentPayload = {
+        x402Version: 1,
+        scheme: "exact",
+        network: "eip155:8453",
+        payload: {
+          signature: "0x" + "ab".repeat(65),
+          authorization: {
+            from: "0x1111111111111111111111111111111111111111",
+            to: "0x2222222222222222222222222222222222222222",
+            value: "100000",
+            validAfter: "0",
+            validBefore: String(Math.floor(Date.now() / 1000) + 3600),
+            nonce: "0x" + "00".repeat(32),
+          },
+        },
+      };
+
+      const requirement: PaymentRequirement = {
+        scheme: "exact",
+        network: "eip155:8453",
+        maxAmountRequired: "100000",
+        resource: "/api/data",
+        description: "Test",
+        mimeType: "application/json",
+        payTo: "0x2222222222222222222222222222222222222222",
+        maxTimeoutSeconds: 60,
+        asset: "0x833589fCD6EDB6E08f4c7C32D4f71b54bdA02913",
+      };
+
+      const result = await verify(payload, requirement);
+      expect(result.isValid).toBe(false);
+      expect(result.invalidReason).toBe("invalid_exact_evm_payload_signature");
     });
 
     it("rejects wrong scheme", async () => {

--- a/packages/x402-server/src/__tests__/utils.test.ts
+++ b/packages/x402-server/src/__tests__/utils.test.ts
@@ -10,6 +10,7 @@ import {
   encodePayload,
   decodePayload,
   NETWORK_CONFIGS,
+  normalizeEvmNetwork,
 } from '../utils.js';
 
 describe('x402-server utils', () => {
@@ -98,10 +99,26 @@ describe('x402-server utils', () => {
       assert.ok(config.asset.startsWith('0x'));
     });
 
+    it('should return canonical config for CAIP-2 aliases', () => {
+      const config = getNetworkConfig('eip155:8453');
+      assert.deepStrictEqual(config, NETWORK_CONFIGS['base']);
+    });
+
     it('should return default config for unknown networks', () => {
       const config = getNetworkConfig('unknown-network');
       assert.ok(config);
       assert.strictEqual(config.decimals, 6);
+    });
+  });
+
+  describe('normalizeEvmNetwork', () => {
+    it('should map CAIP-2 aliases to canonical names', () => {
+      assert.strictEqual(normalizeEvmNetwork('eip155:42161'), 'arbitrum');
+      assert.strictEqual(normalizeEvmNetwork('eip155:84532'), 'base-sepolia');
+    });
+
+    it('should leave canonical names unchanged', () => {
+      assert.strictEqual(normalizeEvmNetwork('base'), 'base');
     });
   });
 

--- a/packages/x402-server/src/middleware.ts
+++ b/packages/x402-server/src/middleware.ts
@@ -18,7 +18,7 @@ import {
   settlePayment,
   encodePaymentResponse,
 } from "./payment.js";
-import { assertSupportedPaymentNetwork } from "./utils.js";
+import { assertSupportedPaymentNetwork, normalizeEvmNetwork } from "./utils.js";
 
 // Express types (minimal to avoid hard dependency)
 interface Request {
@@ -99,11 +99,12 @@ function isFastNetwork(network: string): boolean {
  * Check if network is EVM-based
  */
 function isEvmNetwork(network: string): boolean {
+  const normalizedNetwork = normalizeEvmNetwork(network);
   const evmNetworks = [
     "ethereum", "arbitrum", "arbitrum-sepolia", 
     "base", "base-sepolia", "optimism", "polygon"
   ];
-  return evmNetworks.includes(network) || network.endsWith("-sepolia");
+  return evmNetworks.includes(normalizedNetwork) || normalizedNetwork.endsWith("-sepolia");
 }
 
 /**

--- a/packages/x402-server/src/utils.ts
+++ b/packages/x402-server/src/utils.ts
@@ -11,6 +11,17 @@ import type { NetworkConfig } from "./types.js";
 const FAST_MAINNET_USDC_TOKEN_ID =
   "0xc655a12330da6af361d281b197996d2bc135aaed3b66278e729c2222291e9130";
 
+const EVM_NETWORK_ALIASES: Record<string, string> = {
+  "eip155:1": "ethereum",
+  "eip155:11155111": "ethereum-sepolia",
+  "eip155:42161": "arbitrum",
+  "eip155:421614": "arbitrum-sepolia",
+  "eip155:8453": "base",
+  "eip155:84532": "base-sepolia",
+  "eip155:10": "optimism",
+  "eip155:137": "polygon",
+};
+
 /**
  * EIP-3009 metadata for USDC contracts (x402-specific, not in SDKs)
  */
@@ -108,6 +119,10 @@ function buildNetworkConfigs(): Record<string, NetworkConfig> {
  */
 export const NETWORK_CONFIGS: Record<string, NetworkConfig> = buildNetworkConfigs();
 
+export function normalizeEvmNetwork(network: string): string {
+  return EVM_NETWORK_ALIASES[network] ?? network;
+}
+
 /**
  * Reject deprecated network aliases that no longer map to a valid payment flow.
  */
@@ -145,8 +160,10 @@ export function parsePrice(price: string, decimals: number = 6): string {
  * Get network config, with fallback to generic USDC
  */
 export function getNetworkConfig(network: string): NetworkConfig {
-  if (network in NETWORK_CONFIGS) {
-    return NETWORK_CONFIGS[network];
+  const normalizedNetwork = normalizeEvmNetwork(network);
+
+  if (normalizedNetwork in NETWORK_CONFIGS) {
+    return NETWORK_CONFIGS[normalizedNetwork];
   }
 
   // Default to generic USDC config for unknown networks


### PR DESCRIPTION
## Summary
- normalize CAIP-2 EVM network ids like \ to the canonical x402-client aliases before wallet matching and EVM chain lookup
- apply the same normalization in bridge config resolution so CAIP-2 Base quotes work through the existing bridge path as well
- add regression coverage for x402Pay, EVM signing, and bridge config lookup using CAIP-2 ids

## Testing
- npm run test --workspace @fastxyz/x402-client
- npm run test

Closes #13