### PR TITLE
Add Ethereum support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -413,9 +413,9 @@
       }
     },
     "node_modules/@fastxyz/allset-sdk": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@fastxyz/allset-sdk/-/allset-sdk-0.1.8.tgz",
-      "integrity": "sha512-z8eDpor/cWNyLs613fhjZMhMQ7xn19yBc/22OpQgCfY1iie9JNK1+CzkH80tQ84GoKpQNaX4wYxphxgw+nuuAg==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@fastxyz/allset-sdk/-/allset-sdk-0.1.9.tgz",
+      "integrity": "sha512-DtS70kljJELommRN6DH4x2eHo3+DBFWctfl6GBTLcxoI/xJUxktr4ngVY5o9kHH+evnBwJxExZUoS1GhVc5rzw==",
       "license": "MIT",
       "dependencies": {
         "@mysten/bcs": "^2.0.2",
@@ -2360,7 +2360,7 @@
       "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
-        "@fastxyz/allset-sdk": "^0.1.8"
+        "@fastxyz/allset-sdk": "0.1.9"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -413,9 +413,9 @@
       }
     },
     "node_modules/@fastxyz/allset-sdk": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/@fastxyz/allset-sdk/-/allset-sdk-0.1.9.tgz",
-      "integrity": "sha512-DtS70kljJELommRN6DH4x2eHo3+DBFWctfl6GBTLcxoI/xJUxktr4ngVY5o9kHH+evnBwJxExZUoS1GhVc5rzw==",
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@fastxyz/allset-sdk/-/allset-sdk-0.1.10.tgz",
+      "integrity": "sha512-FDf34KsNAvUZi4QgOKRo3Z0j8oWl7Q1ToZ55Mdjdw3QvubDgoCLTdBZJHgZq+/m5jNs170QBH6qFrueqnkW6CQ==",
       "license": "MIT",
       "dependencies": {
         "@mysten/bcs": "^2.0.2",
@@ -2360,7 +2360,7 @@
       "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
-        "@fastxyz/allset-sdk": "0.1.9"
+        "@fastxyz/allset-sdk": "0.1.10"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x402-sdk",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "private": true,
   "description": "x402 HTTP Payment Protocol SDK - Client, Server, and Facilitator",
   "workspaces": [

--- a/packages/x402-client/src/evm.ts
+++ b/packages/x402-client/src/evm.ts
@@ -5,7 +5,7 @@
  */
 
 import { createPublicClient, http, erc20Abi, type Chain } from 'viem';
-import { sepolia, arbitrumSepolia, baseSepolia, arbitrum, base } from 'viem/chains';
+import { sepolia, arbitrumSepolia, baseSepolia, arbitrum, base, mainnet } from 'viem/chains';
 import { privateKeyToAccount } from 'viem/accounts';
 import type { 
   EvmWallet, 
@@ -33,6 +33,7 @@ const NETWORK_MAP: Record<string, NetworkConfig> = {
   'arbitrum': { chain: arbitrum, network: 'mainnet', chainId: 42161 },
   'base-sepolia': { chain: baseSepolia, network: 'testnet', chainId: 84532 },
   'base': { chain: base, network: 'mainnet', chainId: 8453 },
+  'ethereum': { chain: mainnet, network: 'mainnet', chainId: 1, rpcUrl: process.env.ETH_RPC_URL },
 };
 
 export const EVM_NETWORKS = Object.keys(NETWORK_MAP);

--- a/packages/x402-facilitator/src/chains.ts
+++ b/packages/x402-facilitator/src/chains.ts
@@ -88,7 +88,7 @@ function buildEvmChains(): Record<string, EvmChainConfig> {
   for (const [network, metadata] of Object.entries(EIP3009_METADATA)) {
     // Use appropriate provider based on network
     const provider = MAINNET_CHAINS.has(network) ? mainnetProvider : testnetProvider;
-    
+
     // Try to get USDC address from allset-sdk
     const tokenConfig = provider.getTokenConfig(network, "USDC");
     const usdcAddress =

--- a/packages/x402-server/package.json
+++ b/packages/x402-server/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/fastxyz/x402-sdk#readme",
   "dependencies": {
-    "@fastxyz/allset-sdk": "0.1.9"
+    "@fastxyz/allset-sdk": "0.1.10"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/x402-server/package.json
+++ b/packages/x402-server/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/fastxyz/x402-sdk#readme",
   "dependencies": {
-    "@fastxyz/allset-sdk": "^0.1.8"
+    "@fastxyz/allset-sdk": "0.1.9"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/x402-server/src/utils.ts
+++ b/packages/x402-server/src/utils.ts
@@ -80,7 +80,7 @@ function buildNetworkConfigs(): Record<string, NetworkConfig> {
   }
 
   // EVM mainnet networks from allset-sdk
-  const mainnetNetworks = ["base", "arbitrum"];
+  const mainnetNetworks = ["base", "arbitrum", "ethereum"];
   for (const network of mainnetNetworks) {
     const tokenConfig = mainnetProvider.getTokenConfig(network, "USDC");
     const metadata = EIP3009_METADATA[network];

--- a/skills/client-skill.md
+++ b/skills/client-skill.md
@@ -27,21 +27,6 @@ metadata:
 
 ---
 
-## Supported Networks
-
-| Type | Network | Chain ID | Environment |
-|------|---------|----------|-------------|
-| EVM | `ethereum` | 1 | Mainnet |
-| EVM | `ethereum-sepolia` | 11155111 | Testnet |
-| EVM | `arbitrum` | 42161 | Mainnet |
-| EVM | `arbitrum-sepolia` | 421614 | Testnet |
-| EVM | `base` | 8453 | Mainnet |
-| EVM | `base-sepolia` | 84532 | Testnet |
-| Fast | `fast-mainnet` | — | Mainnet |
-| Fast | `fast-testnet` | — | Testnet |
-
----
-
 ## Decision Tree: Which Wallet?
 
 ```
@@ -50,7 +35,7 @@ What network does the endpoint require?
 ├── Fast network (fast-testnet, fast-mainnet)
 │   └── Use Fast wallet only
 │
-├── EVM network (ethereum, ethereum-sepolia, arbitrum, arbitrum-sepolia, base, base-sepolia)
+├── EVM network (ethereum, ethereum-sepolia, arbitrum, arbitrum-sepolia, base)
 │   │
 │   └── Do you have USDC on that EVM chain?
 │       ├── YES → Use EVM wallet only
@@ -324,6 +309,7 @@ interface X402PayResult {
 | `fast-mainnet` | Fast | USDC |
 | `arbitrum` | EVM | USDC |
 | `base` | EVM | USDC |
+| `ethereum` | EVM | USDC |
 
 ### Testnet
 

--- a/skills/client-skill.md
+++ b/skills/client-skill.md
@@ -27,6 +27,21 @@ metadata:
 
 ---
 
+## Supported Networks
+
+| Type | Network | Chain ID | Environment |
+|------|---------|----------|-------------|
+| EVM | `ethereum` | 1 | Mainnet |
+| EVM | `ethereum-sepolia` | 11155111 | Testnet |
+| EVM | `arbitrum` | 42161 | Mainnet |
+| EVM | `arbitrum-sepolia` | 421614 | Testnet |
+| EVM | `base` | 8453 | Mainnet |
+| EVM | `base-sepolia` | 84532 | Testnet |
+| Fast | `fast-mainnet` | — | Mainnet |
+| Fast | `fast-testnet` | — | Testnet |
+
+---
+
 ## Decision Tree: Which Wallet?
 
 ```
@@ -35,7 +50,7 @@ What network does the endpoint require?
 ├── Fast network (fast-testnet, fast-mainnet)
 │   └── Use Fast wallet only
 │
-├── EVM network (ethereum-sepolia, arbitrum, base, etc.)
+├── EVM network (ethereum, ethereum-sepolia, arbitrum, arbitrum-sepolia, base, base-sepolia)
 │   │
 │   └── Do you have USDC on that EVM chain?
 │       ├── YES → Use EVM wallet only

--- a/skills/facilitator-skill.md
+++ b/skills/facilitator-skill.md
@@ -27,6 +27,21 @@ metadata:
 
 ---
 
+## Supported Networks
+
+| Type | Network | Chain ID | Environment |
+|------|---------|----------|-------------|
+| EVM | `ethereum` | 1 | Mainnet |
+| EVM | `ethereum-sepolia` | 11155111 | Testnet |
+| EVM | `arbitrum` | 42161 | Mainnet |
+| EVM | `arbitrum-sepolia` | 421614 | Testnet |
+| EVM | `base` | 8453 | Mainnet |
+| EVM | `base-sepolia` | 84532 | Testnet |
+| Fast | `fast-mainnet` | — | Mainnet |
+| Fast | `fast-testnet` | — | Testnet |
+
+---
+
 ## Decision Tree: Usage Mode
 
 ```

--- a/skills/facilitator-skill.md
+++ b/skills/facilitator-skill.md
@@ -27,21 +27,6 @@ metadata:
 
 ---
 
-## Supported Networks
-
-| Type | Network | Chain ID | Environment |
-|------|---------|----------|-------------|
-| EVM | `ethereum` | 1 | Mainnet |
-| EVM | `ethereum-sepolia` | 11155111 | Testnet |
-| EVM | `arbitrum` | 42161 | Mainnet |
-| EVM | `arbitrum-sepolia` | 421614 | Testnet |
-| EVM | `base` | 8453 | Mainnet |
-| EVM | `base-sepolia` | 84532 | Testnet |
-| Fast | `fast-mainnet` | — | Mainnet |
-| Fast | `fast-testnet` | — | Testnet |
-
----
-
 ## Decision Tree: Usage Mode
 
 ```
@@ -392,6 +377,7 @@ List supported payment kinds.
 | `fast-mainnet` | Fast | — |
 | `arbitrum` | EVM | 42161 |
 | `base` | EVM | 8453 |
+| `ethereum` | EVM | 1 |
 
 ### Testnet
 

--- a/skills/server-skill.md
+++ b/skills/server-skill.md
@@ -27,6 +27,21 @@ metadata:
 
 ---
 
+## Supported Networks
+
+| Type | Network | Chain ID | Environment |
+|------|---------|----------|-------------|
+| EVM | `ethereum` | 1 | Mainnet |
+| EVM | `ethereum-sepolia` | 11155111 | Testnet |
+| EVM | `arbitrum` | 42161 | Mainnet |
+| EVM | `arbitrum-sepolia` | 421614 | Testnet |
+| EVM | `base` | 8453 | Mainnet |
+| EVM | `base-sepolia` | 84532 | Testnet |
+| Fast | `fast-mainnet` | — | Mainnet |
+| Fast | `fast-testnet` | — | Testnet |
+
+---
+
 ## Decision Tree: Payment Address Setup
 
 ```

--- a/skills/server-skill.md
+++ b/skills/server-skill.md
@@ -27,21 +27,6 @@ metadata:
 
 ---
 
-## Supported Networks
-
-| Type | Network | Chain ID | Environment |
-|------|---------|----------|-------------|
-| EVM | `ethereum` | 1 | Mainnet |
-| EVM | `ethereum-sepolia` | 11155111 | Testnet |
-| EVM | `arbitrum` | 42161 | Mainnet |
-| EVM | `arbitrum-sepolia` | 421614 | Testnet |
-| EVM | `base` | 8453 | Mainnet |
-| EVM | `base-sepolia` | 84532 | Testnet |
-| Fast | `fast-mainnet` | — | Mainnet |
-| Fast | `fast-testnet` | — | Testnet |
-
----
-
 ## Decision Tree: Payment Address Setup
 
 ```
@@ -367,6 +352,7 @@ When payment is required:
 | `fast-mainnet` | Fast | USDC |
 | `arbitrum` | EVM | USDC |
 | `base` | EVM | USDC |
+| `ethereum` | EVM | USDC |
 
 ### Testnet
 


### PR DESCRIPTION
Adds Ethereum mainnet support to the x402-sdk by updating x402-client's EVM chain handling, x402-facilitator's chains config, and x402-server utilities. Bumps allset-sdk dependency to v0.1.10 which includes Ethereum network support. Also removes the 'supported networks' section from client, facilitator, and server skill documentation files since the list was becoming stale.