### PR TITLE
chore: update package versions to 0.1.3 for client, facilitator, and server

### DIFF
--- a/packages/x402-client/package.json
+++ b/packages/x402-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastxyz/x402-client",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Client SDK for x402 HTTP payment protocol - sign and pay for 402-protected content",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/x402-facilitator/package.json
+++ b/packages/x402-facilitator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastxyz/x402-facilitator",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "x402 payment protocol - facilitator SDK for verifying and settling payments on-chain",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/x402-server/package.json
+++ b/packages/x402-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastxyz/x402-server",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "x402 payment protocol - server SDK for creating 402 responses and verifying payments",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Bumps package versions to 0.1.3 for the x402-client, x402-facilitator, and x402-server packages. This is a coordinated version release chore across all three packages in the x402-sdk monorepo.